### PR TITLE
BWE increases slowly when audio packets are sent before video packets.

### DIFF
--- a/src/bwe.rs
+++ b/src/bwe.rs
@@ -82,4 +82,16 @@ impl<'a> Bwe<'a> {
     pub fn set_desired_bitrate(&mut self, desired_bitrate: Bitrate) {
         self.0.session.set_bwe_desired_bitrate(desired_bitrate);
     }
+
+    /// Reset the BWE with a new init_bitrate
+    ///
+    /// # Example
+    ///
+    /// This method is useful when you initially start with only an audio stream. In this case, the BWE will report a very low estimated bitrate.
+    /// Later, when you start a video stream, the estimated bitrate will be affected by the previous low bitrate, resulting in a very low estimated bitrate, which can cause poor video stream quality.
+    /// To avoid this, you need to warm up the video stream for a while then calling reset with a provided init_bitrate.
+    ///
+    pub fn reset(&mut self, init_bitrate: Bitrate) {
+        self.0.session.reset_bwe(init_bitrate);
+    }
 }

--- a/src/packet/bwe/acked_bitrate_estimator.rs
+++ b/src/packet/bwe/acked_bitrate_estimator.rs
@@ -73,8 +73,7 @@ impl AckedBitrateEstimator {
         // current estimate. With low values of uncertainty_symmetry_cap_ we add more
         // uncertainty to increases than to decreases. For higher values we approach
         // symmetry.
-        let sample_uncertainty =
-            scale * (estimate_bps - sample_estimate_bps).abs() / (estimate_bps.max(25_000.0));
+        let sample_uncertainty = scale * (estimate_bps - sample_estimate_bps).abs() / estimate_bps;
         let sample_var = sample_uncertainty.powf(2.0);
 
         // Update a bayesian estimate of the rate, weighting it lower if the sample
@@ -85,6 +84,7 @@ impl AckedBitrateEstimator {
         let mut new_estimate = (sample_var * estimate_bps
             + pred_bitrate_estimate_var * sample_estimate_bps)
             / (sample_var + pred_bitrate_estimate_var);
+
         new_estimate = new_estimate.max(ESTIMATE_FLOOR.as_f64());
         self.estimate = Some(Bitrate::bps(new_estimate.ceil() as u64));
         self.estimate_var =
@@ -136,7 +136,7 @@ impl AckedBitrateEstimator {
 
         self.sum += packet_size;
 
-        estimate.map(|e| (e, false))
+        estimate.map(|e| (e, is_small))
     }
 }
 
@@ -200,7 +200,7 @@ mod test {
 
         assert_eq!(
             estimate.as_u64(),
-            99530,
+            108320,
             "AckedBitrateEstiamtor should produce the correct bitrate"
         );
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -796,6 +796,12 @@ impl Session {
         }
     }
 
+    pub fn reset_bwe(&mut self, init_bitrate: Bitrate) {
+        if let Some(bwe) = self.bwe.as_mut() {
+            bwe.reset(init_bitrate);
+        }
+    }
+
     pub fn line_count(&self) -> usize {
         self.medias.len() + if self.app.is_some() { 1 } else { 0 }
     }
@@ -896,6 +902,10 @@ struct Bwe {
 impl Bwe {
     fn handle_timeout(&mut self, now: Instant) {
         self.bwe.handle_timeout(now);
+    }
+
+    pub fn reset(&mut self, init_bitrate: Bitrate) {
+        self.bwe = SendSideBandwithEstimator::new(init_bitrate);
     }
 
     pub fn update<'t>(


### PR DESCRIPTION
This PR have some changes:

- Fix some missing when porting [bitrate_estimator.cc](https://webrtc.googlesource.com/src/+/9f3ccf291e/modules/congestion_controller/goog_cc/bitrate_estimator.cc) from libwebrtc.
- Added bwe reset API

For more clearly, I will explain what issues lead to this PR. 

## Problem

When an audio stream starts before a video stream, the Bitrate Estimator (BWE) calculates the initial bitrate based on the audio packets. This results in a very low estimated bitrate, typically around 40kbps. When the video stream starts, the BWE struggles to adapt to the increased bandwidth requirements, leading to a slow increase in bitrate. This can cause poor video quality.

```rust
        let sample_estimate_bps = sample_estimate.as_f64();
        let estimate_bps = estimate.as_f64();
        // Define the sample uncertainty as a function of how far away it is from the
        // current estimate. With low values of uncertainty_symmetry_cap_ we add more
        // uncertainty to increases than to decreases. For higher values we approach
        // symmetry.
        let sample_uncertainty =
            scale * (estimate_bps - sample_estimate_bps).abs() / (estimate_bps.max(25_000.0));
        let sample_var = sample_uncertainty.powf(2.0);

        // Update a bayesian estimate of the rate, weighting it lower if the sample
        // uncertainty is large.
        // The bitrate estimate uncertainty is increased with each update to model
        // that the bitrate changes over time.
        let pred_bitrate_estimate_var = self.estimate_var + 5.0;
        let mut new_estimate = (sample_var * estimate_bps
            + pred_bitrate_estimate_var * sample_estimate_bps)
            / (sample_var + pred_bitrate_estimate_var);
        new_estimate = new_estimate.max(ESTIMATE_FLOOR.as_f64());
        self.estimate = Some(Bitrate::bps(new_estimate.ceil() as u64));
        self.estimate_var =
            (sample_var * pred_bitrate_estimate_var) / (sample_var + pred_bitrate_estimate_var);
```

https://github.com/algesten/str0m/blob/a3e0f13744ef8b0681bd34b97298dbe72085878a/src/packet/bwe/acked_bitrate_estimator.rs#L76-91

In my local testing, I observed that the `sample_var` value was around 2000 and the `self.estimate_var` value was around 20. As a result, the BWE increased very slowly. For instance, if the estimated bitrate was 400 and the previous bitrate was 40, the BWE would only increase to 43.6, which is a mere 1% increase. After my configuration of a 2-second warm-up time ends, the video bitrate drops dramatically to around 80 kbps, causing video freezing and very poor quality.

## Solution

This PR introduces a BWE reset API, which allows the BWE to be reset when the server starts sending video packets after an initial period of audio-only packets. This enables the BWE to quickly adapt to the changed bandwidth requirements, ensuring a smoother and more accurate bitrate estimation.

